### PR TITLE
UPDATE

### DIFF
--- a/Makefile.mak
+++ b/Makefile.mak
@@ -43,8 +43,8 @@ print:
 # Help menu of the Makefile
 help:
 	@echo "Available options:"
-	@echo "  make all    : Compiles the program $(EXE)"
-	@echo "  make run    : Runs the program $(EXE)"
-	@echo "  make clean  : Deletes files .o and .mod"
-	@echo "  make print  : Shows the Makefile variables used"
-	@echo "  make help   : Shows this menu"
+	@echo "  make -f Makefile.mak all    : Compiles the program $(EXE)"
+	@echo "  make -f Makefile.mak run    : Runs the program $(EXE)"
+	@echo "  make -f Makefile.mak clean  : Deletes files .o and .mod"
+	@echo "  make -f Makefile.mak print  : Shows the Makefile variables used"
+	@echo "  make -f Makefile.mak help   : Shows this menu"

--- a/README.md
+++ b/README.md
@@ -44,16 +44,20 @@ The different modules that can be found in this Repo are:
 
 ### Executing program
 
-Run the `Makefile.mak` script.
+1. Run the `Makefile.mak` script.
 ```
 make -f Makefile.mak
+```
+2. Execute the output program.
+```
+./calcular
 ```
 
 ## Help
 
 The `Makefile.mak` script has a help menu that can be accessed running the following command:
 ```
-make help
+make -f Makefile.mak help
 ```
 
 ## Authors

--- a/main.f90
+++ b/main.f90
@@ -11,13 +11,17 @@ program main_simulation
     real*8 :: L,temperature,dt,cutoff
     character (len=500) :: simulation_name
     ! reads input file
+    print*, 'START OF SIMULATION.'
     call read_parameters("parameters.nml", dt, N, n_steps, L,&
     simulation_name, temperature, cutoff)
+    print*, 'Parameters of the simulation loaded.'
     ! allocates memory
     allocate(positions(N,3),velocities(N,3))
+    print*, 'Needed arrays allocated.'
     ! initialize system
     call initial_positions(N, L, positions)
     call initial_velocities(N,temperature,velocities)
+    print*, 'System initialized.'
     ! simulation loop
     call main_loop(n_steps, dt, L, cutoff, positions, velocities)
     ! deallocates memory

--- a/potential.f90
+++ b/potential.f90
@@ -73,7 +73,8 @@ contains
                          end if
                    end do
           end do
-          press= (real(npart)*(1.38*10**(-23))*temp)/volume + (1.d0/(3.d0*volume))*Virialterm
+          ! Paula: I added a ".d0" to the 10 because, if not added, is considered as integer and gives 0.
+          press= (real(npart)*(1.38*10.d0**(-23))*temp)/volume + (1.d0/(3.d0*volume))*Virialterm
           
           ! Pressure units are J/m³
           ! we multiply ideal gas term *Kb=1.38*10**(-23)


### PR DESCRIPTION
- README with new instructions to run the program updated. Please use `make -f Makefile.mak clean` and also remove the executable before pushing your updates to the master.
- MAKEFILE improvements. Problem with `.mod` recognition not solved yet. You will need to run the command `make -f Makefile.mak` two times to make it work.
- POTENTIAL.f90 small modification from a 10 to a 10.d0 to avoid 0 or nan when calculating the pressure value.
- SEGMENTATION FAULT ERROR caused by the main loop not solved. 