### PR TITLE
Fixed wrong order in argument list.

### DIFF
--- a/Serial code/readers.f90
+++ b/Serial code/readers.f90
@@ -3,7 +3,7 @@ implicit none
 contains
 
 subroutine read_parameters(param_file, dt, n_particles, n_steps, n_save_pos, L,&
-    simulation_name, cutoff,temperature)
+    simulation_name, temperature,cutoff)
     implicit none
     ! Subroutine to read the simulation parameters from a an nml list
     !


### PR DESCRIPTION
Subroutine was called swapping temperature and cutoff, now the order is correct (wasn't causing obvious numerical errors because the cutoff and the temperature we use are of similar order).